### PR TITLE
Avoid error when file contains audio tracks

### DIFF
--- a/ksg.py
+++ b/ksg.py
@@ -236,8 +236,13 @@ for playlist in root.iterfind('playlist'):
             entryIn = entry.get('in')
             entryOut = entry.get('out')
 
-            # get data from the producer element
+            # find producer element
             producer = root.find("./producer[@id='%s']" % entry.get('producer'))
+            if producer is None:
+                # entry is not a frame
+                continue
+
+            # get data from the producer element
             sourceFile = producer.find("./property/[@name='resource']").text
             sourceWidth = int(producer.find("./property/[@name='meta.media.width']").text)
             sourceHeight = int(producer.find("./property/[@name='meta.media.height']").text)


### PR DESCRIPTION
Huge thanks for this very useful script. 

Currently, the script will throw an error when being fed a file containing audio tracks, since these may contain entries referencing a producer that doesn't exist. For example, I have the following playlist:
```xml

 <playlist id="playlist2">
  <property name="kdenlive:audio_track">1</property>
  <blank length="00:00:02.000" />
  <entry producer="chain0" in="00:00:00.000" out="00:04:20.867">
   <property name="kdenlive:id">225</property>
  </entry>
  <blank length="00:00:04.100" />
  <entry producer="chain2" in="00:00:00.000" out="00:03:27.367">
   <property name="kdenlive:id">223</property>
  </entry>
  <entry producer="chain3" in="00:00:00.000" out="00:02:17.567">
   <property name="kdenlive:id">220</property>
  </entry>
 </playlist>
```
but `chain0` and `chain3` are not producer elements. 

This patch simply ignores entries for which no producer can be found