### PR TITLE
Ignore entries that already have a filter applied

### DIFF
--- a/ksg.py
+++ b/ksg.py
@@ -241,7 +241,13 @@ for playlist in root.iterfind('playlist'):
             sourceFile = producer.find("./property/[@name='resource']").text
             sourceWidth = int(producer.find("./property/[@name='meta.media.width']").text)
             sourceHeight = int(producer.find("./property/[@name='meta.media.height']").text)
-            print ("working on %s" % (sourceFile))
+
+            # skip entry if it already contains a filter
+            if entry.find('filter') is not None:
+                print("skipping %s (a filter already exists)" % (sourceFile))
+                continue
+            else:
+                print ("working on %s" % (sourceFile))
 
             # fill the frame with the image
             hRatio = targetWidth / sourceWidth


### PR DESCRIPTION
Each time the script is run, it will currently add a new filter regardless of any preexisting filter. If the script is run twice, each entry will have two different filters applied. 

The use case I had was that I added photos at the end of the slideshow and re-ran the script every day. This behavior would modify my previous changes. 

This patch checks if any filter already exist for the entry, and only adds the effect to clean entries. 